### PR TITLE
Use Linux .NET 8 images in WebAPI Dockerfile

### DIFF
--- a/WebAPI/Dockerfile
+++ b/WebAPI/Dockerfile
@@ -4,26 +4,26 @@
 # For more information, please see https://aka.ms/containercompat
 
 # This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-nanoserver-1809 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
 
 # This stage is used to build the service project
-FROM mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-1809 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["WebAPI/WebAPI.csproj", "WebAPI/"]
 RUN dotnet restore "./WebAPI/WebAPI.csproj"
 COPY . .
 WORKDIR "/src/WebAPI"
-RUN dotnet build "./WebAPI.csproj" -c %BUILD_CONFIGURATION% -o /app/build
+RUN dotnet build "./WebAPI.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 # This stage is used to publish the service project to be copied to the final stage
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./WebAPI.csproj" -c %BUILD_CONFIGURATION% -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "./WebAPI.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 # This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
 FROM base AS final


### PR DESCRIPTION
## Summary
- Replace Windows-based ASP.NET and SDK images with Linux .NET 8 equivalents
- Update build and publish commands to use Linux environment variable syntax

## Testing
- `dotnet build` *(fails: command not found)*
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c28f5ad374832983928fe3108573d7