### PR TITLE
Run tests before building Docker image and deploy to staging

### DIFF
--- a/.github/workflows/development-ci.yml
+++ b/.github/workflows/development-ci.yml
@@ -1,29 +1,40 @@
+# Continuous integration pipeline for development work.
+# Builds, tests, and publishes a Docker image for the web API.
 name: Development CI
 
 on:
   push:
-    branches: [developing]
+    branches: [development] # Run on pushes to the development branch
   pull_request:
-    branches: [developing]
+    branches: [development] # Run on pull requests targeting development
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Fetch the repository content
       - name: Check out repository
         uses: actions/checkout@v4
 
+      # Install the .NET SDK used by the solution
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.x
 
+      # Restore NuGet packages for the solution
       - name: Restore dependencies
         run: dotnet restore TodoAppWasm.sln
 
+      # Build the solution without restoring again
       - name: Build
         run: dotnet build TodoAppWasm.sln --no-restore
 
+      # Execute unit tests to validate the build
+      - name: Test
+        run: dotnet test TodoAppWasm.sln --no-build
+
+      # Authenticate Docker client with GitHub Container Registry
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -31,8 +42,35 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Docker image
-        run: docker build WebAPI/ -t ghcr.io/${{ github.repository_owner }}/todoappwasm:${{ github.sha }}
+      # Capture repository owner in lowercase for image tagging
+      - name: Set repo owner lowercase
+        run: echo "REPO_OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
+      # Build a Docker image for the WebAPI project
+      - name: Build Docker image
+        run: docker build WebAPI/ -t ghcr.io/${{ env.REPO_OWNER_LC }}/todoappwasm:${{ github.sha }}
+
+      # Push the image to GitHub Container Registry
       - name: Push Docker image
-        run: docker push ghcr.io/${{ github.repository_owner }}/todoappwasm:${{ github.sha }}
+        run: docker push ghcr.io/${{ env.REPO_OWNER_LC }}/todoappwasm:${{ github.sha }}
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      # Capture repository owner in lowercase for image tagging
+      - name: Set repo owner lowercase
+        run: echo "REPO_OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+      # Notify Render to deploy the freshly built image to the staging environment
+      - name: Trigger staging deployment
+        env:
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          IMAGE: ghcr.io/${{ env.REPO_OWNER_LC }}/todoappwasm:${{ github.sha }}
+        run: |
+          curl --fail --show-error -X POST \
+            -H "Authorization: Bearer $RENDER_API_KEY" \
+            -H "Content-Type: application/json" \
+            --data '{"image":"'$IMAGE'","serviceId":"'$RENDER_SERVICE_ID'"}' \
+            https://api.render.com/v1/services/$RENDER_SERVICE_ID/deploys


### PR DESCRIPTION
## Summary
- run unit tests after build in development CI
- prevent pushing docker images if tests fail
- ensure development workflow runs on `development` branch
- document CI workflow steps with inline comments
- ensure GHCR repository owner is lower-case via env variable to avoid unsupported `toLower`
- deploy pushed image to staging via Render using environment secrets and approval, failing on API errors

## Testing
- `dotnet restore TodoAppWasm.sln`
- `dotnet build TodoAppWasm.sln --no-restore`
- `dotnet test TodoAppWasm.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68c2f7a6eaa48329b8ab570bd58d7632