### PR TITLE
Update WebAPI Dockerfile project copy destination

### DIFF
--- a/WebAPI/Dockerfile
+++ b/WebAPI/Dockerfile
@@ -14,7 +14,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
-COPY ["WebAPI.csproj", "."]
+COPY ["WebAPI.csproj", "./"]
 RUN dotnet restore "./WebAPI.csproj"
 COPY . .
 WORKDIR "/src"


### PR DESCRIPTION
## Summary
- adjust the WebAPI Dockerfile COPY instruction to place WebAPI.csproj at the build context root

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c918dbe44c83299c8cb42aa61cf5d5