### PR TITLE
Update Dockerfile to restore project dependencies

### DIFF
--- a/WebAPI/Dockerfile
+++ b/WebAPI/Dockerfile
@@ -14,16 +14,19 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
-COPY ["WebAPI.csproj", "."]
-RUN dotnet restore "./WebAPI.csproj"
+COPY ["WebAPI/WebAPI.csproj", "WebAPI/"]
+COPY ["Application/Application.csproj", "Application/"]
+COPY ["FileData/FileData.csproj", "FileData/"]
+COPY ["Shared/Shared.csproj", "Shared/"]
+RUN dotnet restore "WebAPI/WebAPI.csproj"
 COPY . .
-WORKDIR "/src"
+WORKDIR "/src/WebAPI"
 RUN dotnet build "WebAPI.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 # This stage is used to publish the service project to be copied to the final stage
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./WebAPI.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "WebAPI.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 # This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
 FROM base AS final


### PR DESCRIPTION
## Summary
- copy each project file before restore so the build stage can restore WebAPI/WebAPI.csproj and dependencies
- set the build stage working directory to /src/WebAPI for build and publish commands

## Testing
- docker build -f WebAPI/Dockerfile . *(fails: `docker: command not found` in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9390b84b4832999daae0f73b966b9