### PR TITLE
Initialize reference properties to avoid nullable warnings

### DIFF
--- a/FileData/DataContainer.cs
+++ b/FileData/DataContainer.cs
@@ -9,7 +9,7 @@ namespace FileData
 {
     public class DataContainer
     {
-        public ICollection<User> Users { get; set; }
-        public ICollection<Todo> Todos { get; set; }
+        public ICollection<User> Users { get; set; } = new List<User>();
+        public ICollection<Todo> Todos { get; set; } = new List<Todo>();
     }
 }

--- a/Shared/DTOs/UserCreationDto.cs
+++ b/Shared/DTOs/UserCreationDto.cs
@@ -14,12 +14,12 @@ namespace Shared.DTOs
 
         public string Email { get; set; }
 
-        public string EmailConfirmed { get; set; }
+        public string EmailConfirmed { get; set; } = string.Empty;
 
-        public string EmailConfirmedBy { get; set; }
-        public string EmailConfirmedSubject { get; set; }
+        public string EmailConfirmedBy { get; set; } = string.Empty;
+        public string EmailConfirmedSubject { get; set; } = string.Empty;
 
-        public string EmailConfirmedBody { get; set; }
+        public string EmailConfirmedBody { get; set; } = string.Empty;
 
         public UserCreationDto(String userName, String password, String email)
 

--- a/Shared/Models/Todo.cs
+++ b/Shared/Models/Todo.cs
@@ -14,7 +14,7 @@ namespace Shared.Models
         public string Title { get; set; }
         public bool IsCompleted { get; }
 
-        public string Description { get; set; }
+        public string Description { get; set; } = string.Empty;
 
         public Todo( User owner, string title) { Owner = owner; Title = title; }
 

--- a/Shared/Models/User.cs
+++ b/Shared/Models/User.cs
@@ -10,8 +10,8 @@ namespace Shared.Models
     {
         public int Id { get; set; }
 
-        public string UserName { get; set; }
+        public string UserName { get; set; } = string.Empty;
 
-        public List<Todo> Todos { get; set; }
+        public List<Todo> Todos { get; set; } = new();
     }
 }


### PR DESCRIPTION
## Summary
- provide default values for reference properties in the User and Todo models
- default the email confirmation fields within the user creation DTO
- initialize collection properties in the data container to avoid null references

## Testing
- `dotnet build TodoAppWasm.sln --no-restore` *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc509035308329ac4bf57759bcb9bb