### PR TITLE
Skip staging deploy during pull requests

### DIFF
--- a/.github/workflows/development-ci.yml
+++ b/.github/workflows/development-ci.yml
@@ -59,6 +59,7 @@ jobs:
         run: docker push ghcr.io/${{ env.REPO_OWNER_LC }}/todoappwasm:${{ github.sha }}
 
   deploy:
+    if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
     environment: staging


### PR DESCRIPTION
## Summary
- skip the staging deployment job when the workflow runs for pull request events so that it only deploys on pushes where secrets are available

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_690a5efd01c08329b842781fbbf9a30f