### PR TITLE
Add GitHub Pages deploy for Blazor, app config, CORS updates and deployment docs

### DIFF
--- a/.github/workflows/blazor-github-pages.yml
+++ b/.github/workflows/blazor-github-pages.yml
@@ -1,0 +1,68 @@
+name: Deploy Blazor to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'BlazorApp/**'
+      - 'HttpClients/**'
+      - 'Shared/**'
+      - '.github/workflows/blazor-github-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Configure GitHub Pages base path
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          API_BASE_URL: ${{ secrets.API_BASE_URL }}
+        run: |
+          sed -i "s|<base href=\"/\" />|<base href=\"/$REPO_NAME/\" />|" BlazorApp/wwwroot/index.html
+          if [ -n "$API_BASE_URL" ]; then
+            cat > BlazorApp/wwwroot/appsettings.Production.json <<JSON
+          {
+            "ApiBase": "$API_BASE_URL"
+          }
+          JSON
+          fi
+
+      - name: Publish Blazor WASM
+        run: dotnet publish BlazorApp/BlazorApp.csproj -c Release -o release
+
+      - name: Add .nojekyll
+        run: touch release/wwwroot/.nojekyll
+
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: release/wwwroot
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/BlazorApp/Program.cs
+++ b/BlazorApp/Program.cs
@@ -1,27 +1,28 @@
 using BlazorApp;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
-using HttpClients.ClientInterfaces;     // IUserService, ITodoService
-using HttpClients.Implementations;      // UserHttpClient, TodoHttpClient
-using System.Net.Http;                  // add this if ImplicitUsings are off
+using HttpClients.ClientInterfaces;
+using HttpClients.Implementations;
+using System.Net.Http;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-// Default client for Blazor's own static files (keep this)
 builder.Services.AddScoped(_ => new HttpClient
 {
     BaseAddress = new Uri(builder.HostEnvironment.BaseAddress)
 });
 
-// API base — from config or fallback. Your Swagger shows http://localhost:5112/
-var apiBase = builder.Configuration["ApiBase"] ?? "http://localhost:5112/";
+var apiBase = builder.Configuration["ApiBase"];
+if (string.IsNullOrWhiteSpace(apiBase))
+{
+    apiBase = "http://localhost:5112/";
+}
 
-// Bind each interface to its HttpClient-based implementation (typed clients)
 builder.Services.AddHttpClient<IUserService, UserHttpClient>(c =>
     c.BaseAddress = new Uri(apiBase));
-//builder.Services.AddScoped<ITodoService, TodoHttpClient>();
+
 builder.Services.AddHttpClient<ITodoService, TodoHttpClient>(c =>
     c.BaseAddress = new Uri(apiBase));
 

--- a/BlazorApp/wwwroot/appsettings.Production.json
+++ b/BlazorApp/wwwroot/appsettings.Production.json
@@ -1,0 +1,3 @@
+{
+  "ApiBase": "https://YOUR-VERCEL-API-DOMAIN.vercel.app/"
+}

--- a/BlazorApp/wwwroot/appsettings.json
+++ b/BlazorApp/wwwroot/appsettings.json
@@ -1,0 +1,3 @@
+{
+  "ApiBase": "http://localhost:5112/"
+}

--- a/README.md
+++ b/README.md
@@ -1,25 +1,38 @@
 # TodoAppWasm
 
-## Local Deployment
+A full-stack .NET 8 portfolio project with:
+- **Blazor WebAssembly** front-end (`BlazorApp`)
+- **ASP.NET Core Web API** back-end (`WebAPI`)
 
-### Prerequisites
-- [Docker](https://www.docker.com/) installed on your machine.
+## Deployment plan used in this repository
 
-### Pull the image
+- **Front-end:** GitHub Pages (automated with GitHub Actions)
+- **Back-end:** configurable public API URL (set via `API_BASE_URL` secret)
+
+> You requested Vercel for backend. See the deployment playbook for practical constraints and alternatives.
+
+## CI/CD
+
+- Generic CI: `.github/workflows/ci.yml`
+- Development CI + container publish: `.github/workflows/development-ci.yml`
+- GitHub Pages deploy (Blazor): `.github/workflows/blazor-github-pages.yml`
+
+## Front-end deployment (GitHub Pages)
+
+1. Add repository secret:
+   - `API_BASE_URL=https://<your-public-api-domain>/`
+2. Push to `main`.
+3. Workflow publishes Blazor app to GitHub Pages.
+
+## Back-end configuration for cross-origin calls
+
+Configure the API with explicit allowed origins:
+
 ```bash
-docker pull ghcr.io/<your-namespace>/todoappwasm:latest
-```
-Replace `<your-namespace>` with the appropriate container registry namespace.
-
-### Run the container
-```bash
-docker run -d -p 8080:8080 --name todoappwasm \
-  ghcr.io/<your-namespace>/todoappwasm:latest
+AllowedOrigins=https://<your-username>.github.io
 ```
 
-### Configuration
-The container exposes port `8080`. You can configure the runtime environment by setting the `ASPNETCORE_ENVIRONMENT` variable (defaults to `Production`). For example:
-```bash
-docker run -d -p 8080:8080 -e ASPNETCORE_ENVIRONMENT=Development \
-  ghcr.io/<your-namespace>/todoappwasm:latest
-```
+## Documentation
+
+- Portfolio strategy: [`docs/PORTFOLIO_SHOWCASE_GUIDE.md`](docs/PORTFOLIO_SHOWCASE_GUIDE.md)
+- Deployment details and Vercel clarification: [`docs/DEPLOYMENT_PLAYBOOK.md`](docs/DEPLOYMENT_PLAYBOOK.md)

--- a/WebAPI/Program.cs
+++ b/WebAPI/Program.cs
@@ -2,50 +2,55 @@ using Application.DAO_interfaces;
 using Application.LogicImplementations;
 using Application.LogicInterfaces;
 using EfcDataAccess.DAOs;
-using FileData.DAOs;
-// Removed the problematic line
-// using Application.LogicImplementations; // This namespace does not exist
 using FileData;
 using Application.DAOInterfaces;
 using EfcDataAccess;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-
 builder.Services.AddControllers();
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 builder.Services.AddScoped<FileContext>();
-//builder.Services.AddScoped<IUserDao, UserFileDao>();
 builder.Services.AddScoped<IUserDao, UserEfcDao>();
 builder.Services.AddScoped<IUserLogic, UserLogic>();
 builder.Services.AddScoped<ITodoLogic, TodoLogic>();
-//builder.Services.AddScoped<ITodoDao, TodoFileDao>();
 builder.Services.AddScoped<ITodoDao, TodoEfcDao>();
 builder.Services.AddDbContext<TodoContext>();
 
+var allowedOrigins = builder.Configuration
+    .GetValue<string>("AllowedOrigins")?
+    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+    ?? Array.Empty<string>();
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("FrontendPolicy", policy =>
+    {
+        policy.AllowAnyMethod()
+              .AllowAnyHeader();
+
+        if (allowedOrigins.Length > 0)
+        {
+            policy.WithOrigins(allowedOrigins);
+        }
+        else
+        {
+            policy.AllowAnyOrigin();
+        }
+    });
+});
+
 var app = builder.Build();
 
-app.UseCors(x => x
-    .AllowAnyMethod()
-    .AllowAnyHeader()
-    .SetIsOriginAllowed(origin => true) // allow any origin
-    .AllowCredentials());
-
-// Configure the HTTP request pipeline.
-// if (app.Environment.IsDevelopment())
+app.UseCors("FrontendPolicy");
 
 app.UseSwagger();
-    app.UseSwaggerUI();
-
+app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
-
 app.UseAuthorization();
-
 app.MapControllers();
 
 app.Run();

--- a/docs/DEPLOYMENT_PLAYBOOK.md
+++ b/docs/DEPLOYMENT_PLAYBOOK.md
@@ -1,0 +1,70 @@
+# Deployment Playbook (GitHub Pages Front-end + Vercel Discussion)
+
+## Your target
+
+- Front-end: **GitHub Pages** ✅
+- Back-end: **Vercel** (requested)
+
+## Important technical clarification
+
+For a .NET ASP.NET Core Web API, Vercel is usually **not** the simplest/official runtime target.
+
+Vercel's primary backend runtimes are serverless-focused (Node.js, Python, Go, Rust, etc.), so deploying a full ASP.NET Core API directly is not the standard path.
+
+### What this means for you
+
+You have two realistic options:
+
+1. **Recommended (fastest + least risk):**
+   - Keep front-end on GitHub Pages.
+   - Deploy .NET API on Render/Fly/Railway/Azure free-tier.
+   - Point `ApiBase` to that public API URL.
+
+2. **Vercel-only backend path (higher effort):**
+   - Rebuild API endpoints as Vercel Functions in a supported runtime.
+   - This is effectively a backend rewrite, not simple hosting.
+
+## Implemented in this repository
+
+This repo is now prepared for option #1 (front-end on GitHub Pages + configurable API URL):
+
+- GitHub Pages workflow: `.github/workflows/blazor-github-pages.yml`
+- Production API URL injection via GitHub secret: `API_BASE_URL`
+- Blazor app config files:
+  - `BlazorApp/wwwroot/appsettings.json`
+  - `BlazorApp/wwwroot/appsettings.Production.json`
+- Backend CORS now supports explicit origin allowlist via `AllowedOrigins` config in `WebAPI`.
+
+## Step-by-step rollout
+
+### 1) Enable GitHub Pages deployment
+
+1. Push to `main`.
+2. In repo settings, enable **GitHub Pages** using **GitHub Actions** source.
+3. Add secret `API_BASE_URL` with your public API URL.
+
+### 2) Deploy API
+
+If you still want pure Vercel backend, expect rewrite work.
+If you want fastest completion, deploy current `WebAPI` container on a .NET-friendly host.
+
+### 3) Configure CORS for production
+
+Set backend config:
+
+- `AllowedOrigins=https://<your-username>.github.io`
+
+If using project pages path, origin remains same host (`https://<your-username>.github.io`).
+
+### 4) Verify recruiter experience
+
+- Open GitHub Pages link.
+- Create/read/update/delete one todo.
+- Confirm no CORS or mixed-content (HTTP/HTTPS) errors.
+
+## What I recommend for your portfolio deadline
+
+- Use GitHub Pages now.
+- Use a free .NET-friendly API host now.
+- Mention in README: "Front-end hosted on GitHub Pages, API hosted on free-tier backend (may cold start)."
+- Keep Vercel as optional future experiment only if you want to rewrite backend functions.

--- a/docs/PORTFOLIO_SHOWCASE_GUIDE.md
+++ b/docs/PORTFOLIO_SHOWCASE_GUIDE.md
@@ -1,0 +1,125 @@
+# Portfolio Showcase Guide (TodoAppWasm)
+
+This guide is focused on one objective: make this repository look strong to recruiters while keeping effort realistic.
+
+## 1) What recruiters should immediately understand
+
+When someone opens your repo, they should quickly see:
+
+1. **What it is:** full-stack to-do app (Blazor WASM + ASP.NET Core API).
+2. **What you built:** UI, business logic, data access, tests, containerization, CI/CD.
+3. **How to verify:** clear local run instructions and a live front-end link.
+4. **Engineering maturity:** pipeline, code organization, and known limitations documented.
+
+## 2) Recommended showcase strategy
+
+### Front-end demo (primary)
+
+Deploy the **Blazor WebAssembly app** as a static site on **GitHub Pages** (chosen target).
+
+Why this is best for portfolio:
+- Easy for recruiters to open instantly.
+- No server warm-up delay.
+- No back-end hosting cost required for a first impression.
+
+### Back-end (secondary)
+
+Present back-end in one of two ways:
+- **Option A (preferred for now):** keep back-end local/containerized and document API capabilities clearly.
+- **Option B (public staging deployment):** deploy API to a public URL on a free/low-cost host (for example Render/Fly/Railway depending current free tier), and wire CORS + HTTPS.
+
+**Clarification:** "public staging deployment" simply means a non-production but publicly reachable API endpoint used for demos/recruiter testing.
+
+If API is not publicly hosted, be explicit in README:
+> "Live demo focuses on front-end UX. API is available locally via Docker for technical review."
+
+## 3) CI/CD story you can tell in interviews
+
+Your repo already demonstrates these practices:
+
+- Automated build and tests on push/PR.
+- Docker image build and push to GHCR in development workflow.
+- Deployment trigger to staging (Render).
+
+In interviews, describe this as:
+- "I used GitHub Actions to enforce build/test quality gates."
+- "I publish container images to GHCR for reproducible deployment."
+- "I separated generic CI and environment-specific development workflow."
+
+## 4) README structure for recruiter impact
+
+Use this order in `README.md`:
+
+1. **Project elevator pitch** (2-3 lines).
+2. **Live Demo** (link first, screenshots second).
+3. **Architecture diagram or bullet list**.
+4. **Tech stack**.
+5. **Key features**.
+6. **Local setup** (copy/paste commands).
+7. **Testing and CI/CD**.
+8. **Known limitations + roadmap**.
+9. **Author / contact / CV link**.
+
+## 5) Improvements that give best ROI
+
+If you have limited time, prioritize:
+
+1. **Polish UI and UX in Blazor**
+   - loading states,
+   - empty states,
+   - error toasts/messages,
+   - confirmation for destructive actions.
+
+2. **Improve reliability signals**
+   - add/expand unit tests for app logic,
+   - include one integration-style API test if feasible.
+
+3. **Documentation quality**
+   - architecture explanation,
+   - deployment instructions,
+   - "tradeoffs and next steps" section.
+
+4. **Demo quality**
+   - one short GIF/video in README,
+   - one seeded dataset for predictable demo behavior.
+
+## 6) Proposed task backlog (approve before creating implementation tasks)
+
+The following are suggested tasks. Pick the order before implementation.
+
+### Phase 1 — Must-have (portfolio ready)
+
+- [ ] Add "Live Demo" section + architecture + screenshots to README.
+- [ ] Add front-end deployment workflow (GitHub Pages or Azure Static Web Apps).
+- [ ] Add app configuration documentation (`ApiBase`, environment behavior).
+- [ ] Add "Known Limitations" section with honest back-end hosting note.
+
+### Phase 2 — Quality boost
+
+- [ ] Improve Blazor UX (loading, empty/error states, confirmation modal).
+- [ ] Add focused tests around `Application` logic and critical API behavior.
+- [ ] Add badges (CI status, .NET version, container image location).
+
+### Phase 3 — Nice-to-have
+
+- [ ] Add architecture diagram image in `/docs/assets`.
+- [ ] Add short demo video/GIF.
+- [ ] Add a dedicated `CHANGELOG.md` and release tags.
+
+## 7) How to present this on your CV
+
+Use outcome-oriented wording:
+
+- "Built and deployed a full-stack .NET 8 to-do platform using Blazor WebAssembly and ASP.NET Core Web API."
+- "Implemented CI/CD with GitHub Actions for automated build, test, Docker image publishing, and staged deployment."
+- "Designed layered architecture (UI, HTTP clients, application logic, data access) with reusable DTO/model contracts."
+
+## 8) Suggested immediate decision
+
+Before creating implementation tasks, decide:
+
+1. **Front-end hosting target:** GitHub Pages (selected).
+2. **Back-end approach:** local-only documented vs public staging deployment (public URL for demo).
+3. **Scope for this final polish cycle:** Phase 1 only, or Phase 1 + selected Phase 2 items.
+
+Once these are chosen, task execution can be done in a clean and recruiter-focused sequence.


### PR DESCRIPTION
### Motivation

- Provide an automated GitHub Pages deployment for the Blazor WebAssembly frontend and make the production API URL configurable via repository secrets. 
- Ensure the backend allows cross-origin requests from a known origin list to enable a hosted frontend to communicate with the API securely. 
- Ship minimal runtime config for the Blazor app and document a reproducible deployment/playbook for portfolio presentation. 

### Description

- Add a GitHub Actions workflow `.github/workflows/blazor-github-pages.yml` to build the Blazor WASM site, inject `API_BASE_URL` into `appsettings.Production.json`, and deploy the site to GitHub Pages. 
- Change `BlazorApp/Program.cs` to read `ApiBase` from configuration with a `http://localhost:5112/` fallback and register typed `HttpClient` services for `IUserService` and `ITodoService`. 
- Add front-end configuration files `BlazorApp/wwwroot/appsettings.json` and `BlazorApp/wwwroot/appsettings.Production.json` with `ApiBase` values. 
- Update `WebAPI/Program.cs` to add a named CORS policy (`FrontendPolicy`) that reads `AllowedOrigins` from configuration and applies the policy at app startup, and tidy some service/using lines and DAO registrations. 
- Add documentation files `docs/DEPLOYMENT_PLAYBOOK.md` and `docs/PORTFOLIO_SHOWCASE_GUIDE.md` and extend `README.md` with deployment and CI/CD guidance. 

### Testing

- No automated tests were executed as part of this change; the change adds a GitHub Pages workflow and configuration to be exercised on the next push to `main`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c677612e5c83298725ab3ab60fe757)