### PR TITLE
029 refine get todo by id endpoint

### DIFF
--- a/Application/LogicImplementations/TodoLogic.cs
+++ b/Application/LogicImplementations/TodoLogic.cs
@@ -126,15 +126,22 @@ namespace Application.LogicImplementations
                 throw new AppValidationException("Description must be 200 characters or fewer.");
         }
 
-        public async Task<TodoBasicDto> GetByIdAsync(int id)
+        public async Task<TodoReadDto> GetByIdAsync(int id)
         {
             Todo? todo = await todoDao.GetByIdAsync(id);
             if (todo == null)
             {
-                throw new Exception($"Todo with id {id} not found");
+                throw new NotFoundException($"Todo with id {id} was not found.");
             }
 
-            return new TodoBasicDto(todo.Id, todo.Owner?.UserName ?? string.Empty, todo.Title, todo.IsCompleted);
+            // Return the same read DTO used by list/create endpoints, so clients get a
+            // predictable todo shape whether they request one todo or many.
+            return new TodoReadDto(
+                todo.Id,
+                todo.OwnerId,
+                todo.Title,
+                todo.IsCompleted,
+                todo.Description);
         }
 
             }

--- a/Application/LogicImplementations/TodoLogic.cs
+++ b/Application/LogicImplementations/TodoLogic.cs
@@ -42,12 +42,12 @@ namespace Application.LogicImplementations
             Todo? todo = await todoDao.GetByIdAsync(id);
             if (todo == null)
             {
-                throw new Exception($"Todo with ID {id} was not found!");
+                throw new NotFoundException($"Todo with id {id} was not found.");
             }
 
             if (!todo.IsCompleted)
             {
-                throw new Exception("Cannot delete un-completed Todo!");
+                throw new ConflictException("Cannot delete an incomplete todo.");
             }
 
             await todoDao.DeleteAsync(id);

--- a/Application/LogicImplementations/TodoLogic.cs
+++ b/Application/LogicImplementations/TodoLogic.cs
@@ -47,6 +47,8 @@ namespace Application.LogicImplementations
 
             if (!todo.IsCompleted)
             {
+                // This is a business rule from the todo story: only completed todos may be deleted.
+                // The WebAPI middleware turns this conflict into HTTP 409 for clients.
                 throw new ConflictException("Cannot delete an incomplete todo.");
             }
 
@@ -79,9 +81,13 @@ namespace Application.LogicImplementations
 
             if (dto.IsCompleted != null && existing.IsCompleted && !(bool)dto.IsCompleted)
             {
+                // Once a todo is completed, the app keeps that state final.
+                // Throwing a typed exception lets the API return 409 Conflict instead of 500.
                 throw new ConflictException("Cannot mark a completed todo as incomplete.");
             }
 
+            // Update the tracked entity instead of creating a second object with the same Id.
+            // EF Core can throw tracking errors when two instances share the same primary key.
             existing.OwnerId = dto.OwnerId ?? existing.OwnerId;
             existing.Owner = user ?? existing.Owner;
             existing.Title = dto.Title ?? existing.Title;

--- a/Application/LogicImplementations/TodoLogic.cs
+++ b/Application/LogicImplementations/TodoLogic.cs
@@ -64,7 +64,7 @@ namespace Application.LogicImplementations
 
             if (existing == null)
             {
-                throw new Exception($"Todo with ID {dto.Id} not found!");
+                throw new NotFoundException($"Todo with id {dto.Id} was not found.");
             }
 
             User? user = null;
@@ -79,23 +79,18 @@ namespace Application.LogicImplementations
 
             if (dto.IsCompleted != null && existing.IsCompleted && !(bool)dto.IsCompleted)
             {
-                throw new Exception("Cannot un-complete a completed Todo");
+                throw new ConflictException("Cannot mark a completed todo as incomplete.");
             }
 
-            int ownerIdToUse = dto.OwnerId ?? existing.OwnerId;
-            string titleToUse = dto.Title ?? existing.Title;
-            string? descriptionToUse = dto.Description ?? existing.Description;
-            bool completedToUse = dto.IsCompleted ?? existing.IsCompleted;
+            existing.OwnerId = dto.OwnerId ?? existing.OwnerId;
+            existing.Owner = user ?? existing.Owner;
+            existing.Title = dto.Title ?? existing.Title;
+            existing.Description = dto.Description ?? existing.Description;
+            existing.IsCompleted = dto.IsCompleted ?? existing.IsCompleted;
 
-            Todo updated = new(ownerIdToUse, titleToUse, descriptionToUse)
-            {
-                IsCompleted = completedToUse,
-                Id = existing.Id,
-            };
+            ValidateTodo(existing);
 
-            ValidateTodo(updated);
-
-            await todoDao.UpdateAsync(updated);
+            await todoDao.UpdateAsync(existing);
         }
 
         private void ValidateTodo(Todo dto)

--- a/Application/LogicInterfaces/ITodoLogic.cs
+++ b/Application/LogicInterfaces/ITodoLogic.cs
@@ -17,7 +17,7 @@ namespace Application.LogicInterfaces
 
         Task DeleteAsync(int id);
 
-        Task<TodoBasicDto> GetByIdAsync(int id);
+        Task<TodoReadDto> GetByIdAsync(int id);
 
     }
 }

--- a/BlazorApp/Pages/EditTodo.razor
+++ b/BlazorApp/Pages/EditTodo.razor
@@ -62,13 +62,14 @@
         try
         {
             users = await userService.AsyncGetUsers();
-            TodoBasicDto todoData = await todoService.GetByIdAsync(Id);
-            User currentlyAssigned = users.First(user => user.UserName.Equals(todoData.OwnerName));
+            TodoReadDto todoData = await todoService.GetByIdAsync(Id);
 
             dto = new(Id)
                 {
                     Title = todoData.Title,
-                    OwnerId = currentlyAssigned.Id
+                    OwnerId = todoData.OwnerId,
+                    Description = todoData.Description,
+                    IsCompleted = todoData.IsCompleted
                 };
         }
         catch (Exception e)

--- a/EfcDataAccess/DAOs/TodoEfcDao.cs
+++ b/EfcDataAccess/DAOs/TodoEfcDao.cs
@@ -85,7 +85,11 @@ namespace EfcDataAccess.DAOs
 
         public async Task UpdateAsync(Todo todo)
         {
-            _context.Todos.Update(todo);
+            if (_context.Entry(todo).State == EntityState.Detached)
+            {
+                _context.Todos.Update(todo);
+            }
+
             await _context.SaveChangesAsync();
         }
     }

--- a/EfcDataAccess/DAOs/TodoEfcDao.cs
+++ b/EfcDataAccess/DAOs/TodoEfcDao.cs
@@ -58,10 +58,17 @@ namespace EfcDataAccess.DAOs
                 query = query.Where(t => t.IsCompleted == searchParameterDto.CompletedStatus);
             }
 
-            if (!string.IsNullOrEmpty(searchParameterDto.Titlecontains))
+            if (!string.IsNullOrEmpty(searchParameterDto.TitleContains))
             {
                 query = query.Where(t =>
-                    t.Title.ToLower().Contains(searchParameterDto.Titlecontains.ToLower()));
+                    t.Title.ToLower().Contains(searchParameterDto.TitleContains.ToLower()));
+            }
+
+            if (!string.IsNullOrEmpty(searchParameterDto.DescriptionContains))
+            {
+                query = query.Where(t =>
+                    t.Description != null &&
+                    t.Description.ToLower().Contains(searchParameterDto.DescriptionContains.ToLower()));
             }
 
             List<Todo> result = await query.ToListAsync();

--- a/FileData/DAOs/TodoFileDao.cs
+++ b/FileData/DAOs/TodoFileDao.cs
@@ -68,10 +68,17 @@ namespace FileData.DAOs
                 result = result.Where(t => t.IsCompleted == searchParams.CompletedStatus);
             }
 
-            if (!string.IsNullOrEmpty(searchParams.Titlecontains))
+            if (!string.IsNullOrEmpty(searchParams.TitleContains))
             {
                 result = result.Where(t =>
-                    t.Title.Contains(searchParams.Titlecontains, StringComparison.OrdinalIgnoreCase));
+                    t.Title.Contains(searchParams.TitleContains, StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (!string.IsNullOrEmpty(searchParams.DescriptionContains))
+            {
+                result = result.Where(t =>
+                    t.Description != null &&
+                    t.Description.Contains(searchParams.DescriptionContains, StringComparison.OrdinalIgnoreCase));
             }
 
             return Task.FromResult(result);

--- a/HttpClients/ClientInterfaces/ITodoService.cs
+++ b/HttpClients/ClientInterfaces/ITodoService.cs
@@ -19,7 +19,7 @@ namespace HttpClients.ClientInterfaces
         string? descriptionContains = null
     );
         Task UpdateAsync(TodoUpdateDto dto);
-        Task<TodoBasicDto> GetByIdAsync(int id);
+        Task<TodoReadDto> GetByIdAsync(int id);
         Task DeleteAsync(int id);
 
     }

--- a/HttpClients/ClientInterfaces/ITodoService.cs
+++ b/HttpClients/ClientInterfaces/ITodoService.cs
@@ -15,7 +15,8 @@ namespace HttpClients.ClientInterfaces
         string? userName,
         int? userId,
         bool? completedStatus,
-        string? titleContains
+        string? titleContains,
+        string? descriptionContains = null
     );
         Task UpdateAsync(TodoUpdateDto dto);
         Task<TodoBasicDto> GetByIdAsync(int id);

--- a/HttpClients/Implementations/TodoHttpClient.cs
+++ b/HttpClients/Implementations/TodoHttpClient.cs
@@ -27,9 +27,9 @@ namespace HttpClients.Implementations
             }
         }
 
-        public async Task<ICollection<Todo>> GetAsync(string? userName, int? userId, bool? completedStatus, string? titleContains)
+        public async Task<ICollection<Todo>> GetAsync(string? userName, int? userId, bool? completedStatus, string? titleContains, string? descriptionContains = null)
         {
-            string query = ConstructQuery(userName, userId, completedStatus, titleContains);
+            string query = ConstructQuery(userName, userId, completedStatus, titleContains, descriptionContains);
 
             HttpResponseMessage response = await client.GetAsync("/todos" + query);
             string content = await response.Content.ReadAsStringAsync();
@@ -45,30 +45,36 @@ namespace HttpClients.Implementations
             return todos;
         }
 
-        private static string ConstructQuery(string? userName, int? userId, bool? completedStatus, string? titleContains)
+        private static string ConstructQuery(string? userName, int? userId, bool? completedStatus, string? titleContains, string? descriptionContains)
         {
             string query = "";
             if (!string.IsNullOrEmpty(userName))
             {
-                query += $"?username={userName}";
+                query += $"?userName={Uri.EscapeDataString(userName)}";
             }
 
             if (userId != null)
             {
                 query += string.IsNullOrEmpty(query) ? "?" : "&";
-                query += $"userid={userId}";
+                query += $"userId={userId}";
             }
 
             if (completedStatus != null)
             {
                 query += string.IsNullOrEmpty(query) ? "?" : "&";
-                query += $"completedstatus={completedStatus}";
+                query += $"completedStatus={completedStatus}";
             }
 
             if (!string.IsNullOrEmpty(titleContains))
             {
                 query += string.IsNullOrEmpty(query) ? "?" : "&";
-                query += $"titlecontains={titleContains}";
+                query += $"titleContains={Uri.EscapeDataString(titleContains)}";
+            }
+
+            if (!string.IsNullOrEmpty(descriptionContains))
+            {
+                query += string.IsNullOrEmpty(query) ? "?" : "&";
+                query += $"descriptionContains={Uri.EscapeDataString(descriptionContains)}";
             }
 
             return query;

--- a/HttpClients/Implementations/TodoHttpClient.cs
+++ b/HttpClients/Implementations/TodoHttpClient.cs
@@ -92,7 +92,7 @@ namespace HttpClients.Implementations
             }
         }
 
-        public async Task<TodoBasicDto> GetByIdAsync(int id)
+        public async Task<TodoReadDto> GetByIdAsync(int id)
         {
             HttpResponseMessage response = await client.GetAsync($"/todos/{id}");
             String content = await response.Content.ReadAsStringAsync();
@@ -100,7 +100,7 @@ namespace HttpClients.Implementations
             {
                 throw new Exception(content);
             }
-            TodoBasicDto todo = JsonSerializer.Deserialize<TodoBasicDto>(content,
+            TodoReadDto todo = JsonSerializer.Deserialize<TodoReadDto>(content,
                 new JsonSerializerOptions
 
                 {

--- a/Shared/DTOs/SearchTodoParametersDto.cs
+++ b/Shared/DTOs/SearchTodoParametersDto.cs
@@ -11,20 +11,17 @@ namespace Shared.DTOs
         public string? UserName { get; set; }
         public int ? UserId { get; set; }
         public bool? CompletedStatus { get; set; }
-        public string? Titlecontains { get; set; }
+        public string? TitleContains { get; set; }
 
-        public string? Descriptioncontains { get; set; }
+        public string? DescriptionContains { get; set; }
 
-            public string? Emailcontains { get; set; }
-
-        public SearchTodoParametersDto (string? userName, int? userId, bool? completedStatus, string? titlecontains, string? descriptioncontains, string? emailcontains)
+        public SearchTodoParametersDto (string? userName, int? userId, bool? completedStatus, string? titleContains, string? descriptionContains)
         {
             UserName = userName;
             UserId = userId;
             CompletedStatus = completedStatus;
-            Titlecontains = titlecontains;
-            Descriptioncontains = descriptioncontains;
-            Emailcontains = emailcontains;
+            TitleContains = titleContains;
+            DescriptionContains = descriptionContains;
         }
     }
 }

--- a/Shared/DTOs/TodoUpdateDto.cs
+++ b/Shared/DTOs/TodoUpdateDto.cs
@@ -1,23 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
 
 namespace Shared.DTOs
 {
     public class TodoUpdateDto
     {
+        [Range(1, int.MaxValue, ErrorMessage = "Id must be greater than zero.")]
         public int Id { get; set; }
+
+        [Range(1, int.MaxValue, ErrorMessage = "OwnerId must be greater than zero.")]
         public int? OwnerId { get; set; }
+
+        [MaxLength(50)]
         public string? Title { get; set; }
+
+        [MaxLength(200)]
         public string? Description { get; set; }
-        public String? UserName { get; set; }
+
         public bool? IsCompleted { get; set; }
+
         public TodoUpdateDto(int id)
         {
             Id = id;
         }
-
     }
 }

--- a/Tests/GlobalUsings.cs
+++ b/Tests/GlobalUsings.cs
@@ -1,2 +1,4 @@
 // Makes xUnit attributes and assertions available project-wide without explicit imports
 global using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Tests/TodoFileDaoTests.cs
+++ b/Tests/TodoFileDaoTests.cs
@@ -1,0 +1,113 @@
+using FileData;
+using FileData.DAOs;
+using Shared.DTOs;
+using Shared.Models;
+using Xunit;
+
+namespace Tests;
+
+public class TodoFileDaoTests
+{
+    [Fact]
+    public async Task GetAsync_ReturnsAllTodos_WhenNoFilterIsProvided()
+    {
+        await RunInTempDirectoryAsync(async context =>
+        {
+            SeedTodos(context);
+            var dao = new TodoFileDao(context);
+
+            IEnumerable<Todo> todos = await dao.GetAsync(new SearchTodoParametersDto(null, null, null, null, null));
+
+            Assert.Equal(3, todos.Count());
+        });
+    }
+
+    [Fact]
+    public async Task GetAsync_FiltersTodos_ByUserId()
+    {
+        await RunInTempDirectoryAsync(async context =>
+        {
+            SeedTodos(context);
+            var dao = new TodoFileDao(context);
+
+            IEnumerable<Todo> todos = await dao.GetAsync(new SearchTodoParametersDto(null, 2, null, null, null));
+
+            Todo todo = Assert.Single(todos);
+            Assert.Equal("Submit portfolio", todo.Title);
+        });
+    }
+
+    [Fact]
+    public async Task GetAsync_FiltersTodos_ByCompletedStatus()
+    {
+        await RunInTempDirectoryAsync(async context =>
+        {
+            SeedTodos(context);
+            var dao = new TodoFileDao(context);
+
+            IEnumerable<Todo> todos = await dao.GetAsync(new SearchTodoParametersDto(null, null, true, null, null));
+
+            Assert.Equal(new[] { "Buy groceries" }, todos.Select(todo => todo.Title));
+        });
+    }
+
+    [Fact]
+    public async Task GetAsync_FiltersTodos_ByTitleContains()
+    {
+        await RunInTempDirectoryAsync(async context =>
+        {
+            SeedTodos(context);
+            var dao = new TodoFileDao(context);
+
+            IEnumerable<Todo> todos = await dao.GetAsync(new SearchTodoParametersDto(null, null, null, "portfolio", null));
+
+            Todo todo = Assert.Single(todos);
+            Assert.Equal("Submit portfolio", todo.Title);
+        });
+    }
+
+    [Fact]
+    public async Task GetAsync_FiltersTodos_ByDescriptionContains()
+    {
+        await RunInTempDirectoryAsync(async context =>
+        {
+            SeedTodos(context);
+            var dao = new TodoFileDao(context);
+
+            IEnumerable<Todo> todos = await dao.GetAsync(new SearchTodoParametersDto(null, null, null, null, "milk"));
+
+            Todo todo = Assert.Single(todos);
+            Assert.Equal("Buy groceries", todo.Title);
+        });
+    }
+
+    private static void SeedTodos(FileContext context)
+    {
+        User john = new() { Id = 1, UserName = "john" };
+        User sarah = new() { Id = 2, UserName = "sarah" };
+
+        context.Users.Add(john);
+        context.Users.Add(sarah);
+        context.Todos.Add(new Todo(john, "Buy groceries", "Remember milk") { Id = 1, IsCompleted = true });
+        context.Todos.Add(new Todo(john, "Book dentist", "Annual checkup") { Id = 2 });
+        context.Todos.Add(new Todo(sarah, "Submit portfolio", "Backend user stories") { Id = 3 });
+    }
+
+    private static async Task RunInTempDirectoryAsync(Func<FileContext, Task> test)
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        string originalDir = Directory.GetCurrentDirectory();
+        Directory.SetCurrentDirectory(tempDir);
+
+        try
+        {
+            await test(new FileContext());
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalDir);
+            Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/Tests/TodoLogicTests.cs
+++ b/Tests/TodoLogicTests.cs
@@ -134,6 +134,30 @@ public class TodoLogicTests
         await Assert.ThrowsAsync<ConflictException>(() => logic.DeleteAsync(1));
     }
 
+    [Fact]
+    public async Task GetByIdAsync_ReturnsTodoReadDto_WhenTodoExists()
+    {
+        var todoDao = new FakeTodoDao();
+        todoDao.Todos.Add(new Todo(2, "Read one todo", "Useful details") { Id = 5, IsCompleted = true });
+        var logic = new TodoLogic(todoDao, new FakeUserDao());
+
+        TodoReadDto result = await logic.GetByIdAsync(5);
+
+        Assert.Equal(5, result.Id);
+        Assert.Equal(2, result.OwnerId);
+        Assert.Equal("Read one todo", result.Title);
+        Assert.Equal("Useful details", result.Description);
+        Assert.True(result.IsCompleted);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ThrowsNotFound_WhenTodoDoesNotExist()
+    {
+        var logic = new TodoLogic(new FakeTodoDao(), new FakeUserDao());
+
+        await Assert.ThrowsAsync<NotFoundException>(() => logic.GetByIdAsync(404));
+    }
+
     private class FakeTodoDao : ITodoDao
     {
         public IList<Todo> Todos { get; } = new List<Todo>();

--- a/Tests/TodoLogicTests.cs
+++ b/Tests/TodoLogicTests.cs
@@ -104,6 +104,36 @@ public class TodoLogicTests
         }));
     }
 
+    [Fact]
+    public async Task DeleteAsync_DeletesTodo_WhenTodoIsCompleted()
+    {
+        var todoDao = new FakeTodoDao();
+        todoDao.Todos.Add(new Todo(1, "Completed todo") { Id = 1, IsCompleted = true });
+        var logic = new TodoLogic(todoDao, new FakeUserDao());
+
+        await logic.DeleteAsync(1);
+
+        Assert.Empty(todoDao.Todos);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ThrowsNotFound_WhenTodoDoesNotExist()
+    {
+        var logic = new TodoLogic(new FakeTodoDao(), new FakeUserDao());
+
+        await Assert.ThrowsAsync<NotFoundException>(() => logic.DeleteAsync(99));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ThrowsConflict_WhenTodoIsIncomplete()
+    {
+        var todoDao = new FakeTodoDao();
+        todoDao.Todos.Add(new Todo(1, "Incomplete todo") { Id = 1, IsCompleted = false });
+        var logic = new TodoLogic(todoDao, new FakeUserDao());
+
+        await Assert.ThrowsAsync<ConflictException>(() => logic.DeleteAsync(1));
+    }
+
     private class FakeTodoDao : ITodoDao
     {
         public IList<Todo> Todos { get; } = new List<Todo>();

--- a/Tests/TodoLogicTests.cs
+++ b/Tests/TodoLogicTests.cs
@@ -1,0 +1,176 @@
+using Application.DAO_interfaces;
+using Application.DAOInterfaces;
+using Application.Exceptions;
+using Application.LogicImplementations;
+using Shared.DTOs;
+using Shared.Models;
+using Xunit;
+
+namespace Tests;
+
+public class TodoLogicTests
+{
+    [Fact]
+    public async Task UpdateAsync_UpdatesTodo_WhenRequestIsValid()
+    {
+        var todoDao = new FakeTodoDao();
+        var userDao = new FakeUserDao();
+        userDao.Users.Add(new User { Id = 1, UserName = "john" });
+        todoDao.Todos.Add(new Todo(1, "Old title", "Old description") { Id = 1 });
+        var logic = new TodoLogic(todoDao, userDao);
+
+        await logic.UpdateAsync(new TodoUpdateDto(1)
+        {
+            Title = "New title",
+            Description = "New description",
+            IsCompleted = true
+        });
+
+        Todo updated = Assert.Single(todoDao.Todos);
+        Assert.Equal("New title", updated.Title);
+        Assert.Equal("New description", updated.Description);
+        Assert.True(updated.IsCompleted);
+        Assert.Equal(1, updated.OwnerId);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ThrowsNotFound_WhenTodoDoesNotExist()
+    {
+        var logic = new TodoLogic(new FakeTodoDao(), new FakeUserDao());
+
+        await Assert.ThrowsAsync<NotFoundException>(() => logic.UpdateAsync(new TodoUpdateDto(99)));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ChangesOwner_WhenOwnerExists()
+    {
+        var todoDao = new FakeTodoDao();
+        var userDao = new FakeUserDao();
+        userDao.Users.Add(new User { Id = 1, UserName = "john" });
+        userDao.Users.Add(new User { Id = 2, UserName = "sarah" });
+        todoDao.Todos.Add(new Todo(1, "Existing todo") { Id = 1 });
+        var logic = new TodoLogic(todoDao, userDao);
+
+        await logic.UpdateAsync(new TodoUpdateDto(1)
+        {
+            OwnerId = 2
+        });
+
+        Todo updated = Assert.Single(todoDao.Todos);
+        Assert.Equal(2, updated.OwnerId);
+        Assert.Equal("sarah", updated.Owner?.UserName);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ThrowsNotFound_WhenNewOwnerDoesNotExist()
+    {
+        var todoDao = new FakeTodoDao();
+        todoDao.Todos.Add(new Todo(1, "Existing todo") { Id = 1 });
+        var logic = new TodoLogic(todoDao, new FakeUserDao());
+
+        await Assert.ThrowsAsync<NotFoundException>(() => logic.UpdateAsync(new TodoUpdateDto(1)
+        {
+            OwnerId = 77
+        }));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ThrowsConflict_WhenCompletedTodoIsMarkedIncomplete()
+    {
+        var todoDao = new FakeTodoDao();
+        var userDao = new FakeUserDao();
+        userDao.Users.Add(new User { Id = 1, UserName = "john" });
+        todoDao.Todos.Add(new Todo(1, "Existing todo") { Id = 1, IsCompleted = true });
+        var logic = new TodoLogic(todoDao, userDao);
+
+        await Assert.ThrowsAsync<ConflictException>(() => logic.UpdateAsync(new TodoUpdateDto(1)
+        {
+            IsCompleted = false
+        }));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ThrowsValidation_WhenTitleIsEmpty()
+    {
+        var todoDao = new FakeTodoDao();
+        var userDao = new FakeUserDao();
+        userDao.Users.Add(new User { Id = 1, UserName = "john" });
+        todoDao.Todos.Add(new Todo(1, "Existing todo") { Id = 1 });
+        var logic = new TodoLogic(todoDao, userDao);
+
+        await Assert.ThrowsAsync<AppValidationException>(() => logic.UpdateAsync(new TodoUpdateDto(1)
+        {
+            Title = ""
+        }));
+    }
+
+    private class FakeTodoDao : ITodoDao
+    {
+        public IList<Todo> Todos { get; } = new List<Todo>();
+
+        public Task<Todo> CreateAsync(Todo todo)
+        {
+            Todos.Add(todo);
+            return Task.FromResult(todo);
+        }
+
+        public Task DeleteAsync(int id)
+        {
+            Todo? todo = Todos.FirstOrDefault(t => t.Id == id);
+            if (todo != null)
+            {
+                Todos.Remove(todo);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task<IEnumerable<Todo>> GetAsync(SearchTodoParametersDto searchParameterDto)
+        {
+            return Task.FromResult(Todos.AsEnumerable());
+        }
+
+        public Task<Todo?> GetByIdAsync(int todoId)
+        {
+            return Task.FromResult(Todos.FirstOrDefault(t => t.Id == todoId));
+        }
+
+        public Task UpdateAsync(Todo todo)
+        {
+            Todo? existing = Todos.FirstOrDefault(t => t.Id == todo.Id);
+            if (existing != null)
+            {
+                Todos.Remove(existing);
+            }
+
+            Todos.Add(todo);
+            return Task.CompletedTask;
+        }
+    }
+
+    private class FakeUserDao : IUserDao
+    {
+        public IList<User> Users { get; } = new List<User>();
+
+        public Task<User> CreateAsync(User user)
+        {
+            Users.Add(user);
+            return Task.FromResult(user);
+        }
+
+        public Task<IEnumerable<User>> GetAllAsync(SearchUserParametersDto searchUserParametersDto)
+        {
+            return Task.FromResult(Users.AsEnumerable());
+        }
+
+        public Task<User?> GetByIdAsync(int id)
+        {
+            return Task.FromResult(Users.FirstOrDefault(user => user.Id == id));
+        }
+
+        public Task<User?> GetByUsernameAsync(string userName)
+        {
+            return Task.FromResult(Users.FirstOrDefault(user => user.UserName == userName));
+        }
+    }
+}

--- a/WebAPI/Controllers/TodosController.cs
+++ b/WebAPI/Controllers/TodosController.cs
@@ -52,13 +52,27 @@ namespace WebAPI.Controllers
         }
 
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<Todo>>> GetAsync([FromQuery] string? userName, [FromQuery] int? userId, [FromQuery] bool? completedStatus, [FromQuery] string? titleContains, [FromQuery] string? descriptionsContain, [FromBody] string? emailContain)
+        [ProducesResponseType(typeof(IEnumerable<TodoReadDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult<IEnumerable<TodoReadDto>>> GetAsync(
+            [FromQuery] string? userName,
+            [FromQuery] int? userId,
+            [FromQuery] bool? completedStatus,
+            [FromQuery] string? titleContains,
+            [FromQuery] string? descriptionContains)
         {
             try
             {
-                SearchTodoParametersDto parameters = new(userName, userId, completedStatus, titleContains, descriptionsContain, emailContain);
+                SearchTodoParametersDto parameters = new(userName, userId, completedStatus, titleContains, descriptionContains);
                 var todos = await todoLogic.GetAsync(parameters);
-                return Ok(todos);
+                IEnumerable<TodoReadDto> response = todos.Select(todo => new TodoReadDto(
+                    todo.Id,
+                    todo.OwnerId,
+                    todo.Title,
+                    todo.IsCompleted,
+                    todo.Description));
+
+                return Ok(response);
             }
             catch (Exception e)
             {

--- a/WebAPI/Controllers/TodosController.cs
+++ b/WebAPI/Controllers/TodosController.cs
@@ -88,11 +88,14 @@ namespace WebAPI.Controllers
         }
 
         [HttpGet("{id:int}")]
-        [ProducesResponseType(typeof(TodoBasicDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(TodoReadDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
-        public async Task<ActionResult<TodoBasicDto>> GetById([FromRoute] int id)
+        public async Task<ActionResult<TodoReadDto>> GetById([FromRoute] int id)
         {
-            TodoBasicDto result = await todoLogic.GetByIdAsync(id);
+            // The middleware handles NotFoundException, so this method can stay focused
+            // on the happy path: ask the application layer for one todo and return it.
+            TodoReadDto result = await todoLogic.GetByIdAsync(id);
             return Ok(result);
         }
     }

--- a/WebAPI/Controllers/TodosController.cs
+++ b/WebAPI/Controllers/TodosController.cs
@@ -82,12 +82,29 @@ namespace WebAPI.Controllers
         }
 
         [HttpPatch]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status409Conflict)]
+        [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
         public async Task<ActionResult> UpdateAsync([FromBody] TodoUpdateDto dto)
         {
             try
             {
                 await todoLogic.UpdateAsync(dto);
-                return Ok();
+                return NoContent();
+            }
+            catch (AppValidationException e)
+            {
+                return BadRequest(new ApiErrorDto(e.Message));
+            }
+            catch (NotFoundException e)
+            {
+                return NotFound(new ApiErrorDto(e.Message));
+            }
+            catch (ConflictException e)
+            {
+                return Conflict(new ApiErrorDto(e.Message));
             }
             catch (Exception e)
             {

--- a/WebAPI/Controllers/TodosController.cs
+++ b/WebAPI/Controllers/TodosController.cs
@@ -1,4 +1,3 @@
-using Application.Exceptions;
 using Application.LogicInterfaces;
 using Microsoft.AspNetCore.Mvc;
 using Shared.DTOs;
@@ -24,31 +23,15 @@ namespace WebAPI.Controllers
         [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
         public async Task<ActionResult<TodoReadDto>> CreateAsync([FromBody] TodoCreationDto dto)
         {
-            try
-            {
-                Todo created = await todoLogic.CreateAsync(dto);
-                TodoReadDto response = new(
-                    created.Id,
-                    created.OwnerId,
-                    created.Title,
-                    created.IsCompleted,
-                    created.Description);
+            Todo created = await todoLogic.CreateAsync(dto);
+            TodoReadDto response = new(
+                created.Id,
+                created.OwnerId,
+                created.Title,
+                created.IsCompleted,
+                created.Description);
 
-                return Created($"/todos/{created.Id}", response);
-            }
-            catch (AppValidationException e)
-            {
-                return BadRequest(new ApiErrorDto(e.Message));
-            }
-            catch (NotFoundException e)
-            {
-                return NotFound(new ApiErrorDto(e.Message));
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-                return StatusCode(500, new ApiErrorDto("An unexpected error occurred while creating the todo."));
-            }
+            return Created($"/todos/{created.Id}", response);
         }
 
         [HttpGet]
@@ -61,24 +44,16 @@ namespace WebAPI.Controllers
             [FromQuery] string? titleContains,
             [FromQuery] string? descriptionContains)
         {
-            try
-            {
-                SearchTodoParametersDto parameters = new(userName, userId, completedStatus, titleContains, descriptionContains);
-                var todos = await todoLogic.GetAsync(parameters);
-                IEnumerable<TodoReadDto> response = todos.Select(todo => new TodoReadDto(
-                    todo.Id,
-                    todo.OwnerId,
-                    todo.Title,
-                    todo.IsCompleted,
-                    todo.Description));
+            SearchTodoParametersDto parameters = new(userName, userId, completedStatus, titleContains, descriptionContains);
+            var todos = await todoLogic.GetAsync(parameters);
+            IEnumerable<TodoReadDto> response = todos.Select(todo => new TodoReadDto(
+                todo.Id,
+                todo.OwnerId,
+                todo.Title,
+                todo.IsCompleted,
+                todo.Description));
 
-                return Ok(response);
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-                return StatusCode(500, new ApiErrorDto("An unexpected error occurred while fetching todos."));
-            }
+            return Ok(response);
         }
 
         [HttpPatch]
@@ -89,58 +64,28 @@ namespace WebAPI.Controllers
         [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
         public async Task<ActionResult> UpdateAsync([FromBody] TodoUpdateDto dto)
         {
-            try
-            {
-                await todoLogic.UpdateAsync(dto);
-                return NoContent();
-            }
-            catch (AppValidationException e)
-            {
-                return BadRequest(new ApiErrorDto(e.Message));
-            }
-            catch (NotFoundException e)
-            {
-                return NotFound(new ApiErrorDto(e.Message));
-            }
-            catch (ConflictException e)
-            {
-                return Conflict(new ApiErrorDto(e.Message));
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-                return StatusCode(500, new ApiErrorDto("An unexpected error occurred while updating the todo."));
-            }
+            await todoLogic.UpdateAsync(dto);
+            return NoContent();
         }
 
         [HttpDelete("{id:int}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status409Conflict)]
+        [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
         public async Task<ActionResult> DeleteAsync([FromRoute] int id)
         {
-            try
-            {
-                await todoLogic.DeleteAsync(id);
-                return Ok();
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-                return StatusCode(500, new ApiErrorDto("An unexpected error occurred while deleting the todo."));
-            }
+            await todoLogic.DeleteAsync(id);
+            return NoContent();
         }
 
         [HttpGet("{id:int}")]
+        [ProducesResponseType(typeof(TodoBasicDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
         public async Task<ActionResult<TodoBasicDto>> GetById([FromRoute] int id)
         {
-            try
-            {
-                TodoBasicDto result = await todoLogic.GetByIdAsync(id);
-                return Ok(result);
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-                return StatusCode(500, new ApiErrorDto("An unexpected error occurred while fetching the todo."));
-            }
+            TodoBasicDto result = await todoLogic.GetByIdAsync(id);
+            return Ok(result);
         }
     }
 }

--- a/WebAPI/Controllers/TodosController.cs
+++ b/WebAPI/Controllers/TodosController.cs
@@ -24,6 +24,9 @@ namespace WebAPI.Controllers
         public async Task<ActionResult<TodoReadDto>> CreateAsync([FromBody] TodoCreationDto dto)
         {
             Todo created = await todoLogic.CreateAsync(dto);
+
+            // Return a read DTO instead of the EF/domain model so the API contract stays stable
+            // even if the internal database model changes later.
             TodoReadDto response = new(
                 created.Id,
                 created.OwnerId,
@@ -46,6 +49,9 @@ namespace WebAPI.Controllers
         {
             SearchTodoParametersDto parameters = new(userName, userId, completedStatus, titleContains, descriptionContains);
             var todos = await todoLogic.GetAsync(parameters);
+
+            // Controllers translate application results into API responses; filtering and
+            // business decisions stay in the application/data layers.
             IEnumerable<TodoReadDto> response = todos.Select(todo => new TodoReadDto(
                 todo.Id,
                 todo.OwnerId,
@@ -76,6 +82,8 @@ namespace WebAPI.Controllers
         public async Task<ActionResult> DeleteAsync([FromRoute] int id)
         {
             await todoLogic.DeleteAsync(id);
+
+            // DELETE has no response body on success; the status code is enough for the client.
             return NoContent();
         }
 

--- a/WebAPI/Controllers/UsersController.cs
+++ b/WebAPI/Controllers/UsersController.cs
@@ -1,4 +1,3 @@
-using Application.Exceptions;
 using Application.LogicInterfaces;
 using Microsoft.AspNetCore.Mvc;
 using Shared.DTOs;
@@ -24,25 +23,9 @@ namespace WebAPI.Controllers
         [ProducesResponseType(typeof(ApiErrorDto), StatusCodes.Status500InternalServerError)]
         public async Task<ActionResult<UserReadDto>> CreateAsync([FromBody] UserCreationDto dto)
         {
-            try
-            {
-                User user = await userLogic.CreateAsync(dto);
-                UserReadDto response = new(user.Id, user.UserName);
-                return Created($"/users/{user.Id}", response);
-            }
-            catch (AppValidationException e)
-            {
-                return BadRequest(new ApiErrorDto(e.Message));
-            }
-            catch (ConflictException e)
-            {
-                return Conflict(new ApiErrorDto(e.Message));
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-                return StatusCode(500, new ApiErrorDto("An unexpected error occurred while creating the user."));
-            }
+            User user = await userLogic.CreateAsync(dto);
+            UserReadDto response = new(user.Id, user.UserName);
+            return Created($"/users/{user.Id}", response);
         }
 
         [HttpGet]
@@ -52,18 +35,10 @@ namespace WebAPI.Controllers
             [FromQuery] string? usernameContains,
             [FromQuery] int? userId)
         {
-            try
-            {
-                SearchUserParametersDto parameters = new(usernameContains, userId);
-                IEnumerable<User> users = await userLogic.GetAsync(parameters);
-                IEnumerable<UserReadDto> response = users.Select(user => new UserReadDto(user.Id, user.UserName));
-                return Ok(response);
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-                return StatusCode(500, new ApiErrorDto("An unexpected error occurred while fetching users."));
-            }
+            SearchUserParametersDto parameters = new(usernameContains, userId);
+            IEnumerable<User> users = await userLogic.GetAsync(parameters);
+            IEnumerable<UserReadDto> response = users.Select(user => new UserReadDto(user.Id, user.UserName));
+            return Ok(response);
         }
     }
 }

--- a/WebAPI/Middleware/ApiExceptionMiddleware.cs
+++ b/WebAPI/Middleware/ApiExceptionMiddleware.cs
@@ -28,6 +28,8 @@ namespace WebAPI.Middleware
 
         private async Task HandleExceptionAsync(HttpContext context, Exception exception)
         {
+            // Application exceptions represent expected API outcomes, not server crashes.
+            // Mapping them here keeps status codes consistent across all controllers.
             int statusCode = exception switch
             {
                 AppValidationException => StatusCodes.Status400BadRequest,
@@ -40,6 +42,8 @@ namespace WebAPI.Middleware
                 ? "An unexpected error occurred."
                 : exception.Message;
 
+            // Only hide/log unexpected errors. Validation/not-found/conflict messages are safe
+            // to return because they explain what the client should fix.
             if (statusCode == StatusCodes.Status500InternalServerError)
             {
                 logger.LogError(exception, "Unhandled API exception.");

--- a/WebAPI/Middleware/ApiExceptionMiddleware.cs
+++ b/WebAPI/Middleware/ApiExceptionMiddleware.cs
@@ -1,0 +1,53 @@
+using Application.Exceptions;
+using Shared.DTOs;
+
+namespace WebAPI.Middleware
+{
+    public class ApiExceptionMiddleware
+    {
+        private readonly RequestDelegate next;
+        private readonly ILogger<ApiExceptionMiddleware> logger;
+
+        public ApiExceptionMiddleware(RequestDelegate next, ILogger<ApiExceptionMiddleware> logger)
+        {
+            this.next = next;
+            this.logger = logger;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            try
+            {
+                await next(context);
+            }
+            catch (Exception exception)
+            {
+                await HandleExceptionAsync(context, exception);
+            }
+        }
+
+        private async Task HandleExceptionAsync(HttpContext context, Exception exception)
+        {
+            int statusCode = exception switch
+            {
+                AppValidationException => StatusCodes.Status400BadRequest,
+                NotFoundException => StatusCodes.Status404NotFound,
+                ConflictException => StatusCodes.Status409Conflict,
+                _ => StatusCodes.Status500InternalServerError
+            };
+
+            string message = statusCode == StatusCodes.Status500InternalServerError
+                ? "An unexpected error occurred."
+                : exception.Message;
+
+            if (statusCode == StatusCodes.Status500InternalServerError)
+            {
+                logger.LogError(exception, "Unhandled API exception.");
+            }
+
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsJsonAsync(new ApiErrorDto(message));
+        }
+    }
+}

--- a/WebAPI/Program.cs
+++ b/WebAPI/Program.cs
@@ -14,6 +14,8 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 builder.Services.AddScoped<FileContext>();
+// Register interfaces against concrete classes so controllers depend on abstractions,
+// while Program.cs decides whether the app uses EF Core, file storage, or another data source.
 builder.Services.AddScoped<IUserDao, UserEfcDao>();
 builder.Services.AddScoped<IUserLogic, UserLogic>();
 builder.Services.AddScoped<ITodoLogic, TodoLogic>();
@@ -45,6 +47,8 @@ builder.Services.AddCors(options =>
 
 var app = builder.Build();
 
+// Convert domain/application exceptions into consistent HTTP responses in one place.
+// This keeps controllers focused on request/response flow instead of repeating try/catch blocks.
 app.UseMiddleware<ApiExceptionMiddleware>();
 
 app.UseCors("FrontendPolicy");

--- a/WebAPI/Program.cs
+++ b/WebAPI/Program.cs
@@ -5,6 +5,7 @@ using EfcDataAccess.DAOs;
 using FileData;
 using Application.DAOInterfaces;
 using EfcDataAccess;
+using WebAPI.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -43,6 +44,8 @@ builder.Services.AddCors(options =>
 });
 
 var app = builder.Build();
+
+app.UseMiddleware<ApiExceptionMiddleware>();
 
 app.UseCors("FrontendPolicy");
 


### PR DESCRIPTION
Refine GET /Todos/{id} to return the shared TodoReadDto contract, map missing todos to 404 through middleware, update the client contract, and add get-by-id tests.
