### PR TITLE
Fix GitHub Pages navigation after login

### DIFF
--- a/BlazorApp/Pages/CreateTodo.razor
+++ b/BlazorApp/Pages/CreateTodo.razor
@@ -64,6 +64,6 @@
     private void Proceed()
     {
         showModal = false;
-        navMgr.NavigateTo("/ViewTodos");
+        navMgr.NavigateTo("ViewTodos");
     }
 }

--- a/BlazorApp/Pages/EditTodo.razor
+++ b/BlazorApp/Pages/EditTodo.razor
@@ -65,7 +65,7 @@
         try
         {
             await todoService.UpdateAsync(dto);
-            navMgr.NavigateTo("/ViewTodos");
+            navMgr.NavigateTo("ViewTodos");
         }
         catch (Exception e)
         {

--- a/BlazorApp/Pages/Login.razor
+++ b/BlazorApp/Pages/Login.razor
@@ -47,7 +47,7 @@
         try
         {
             await AuthService.LoginAsync(new UserLoginDto(username, password));
-            NavMgr.NavigateTo("/ViewTodos");
+            NavMgr.NavigateTo("ViewTodos");
         }
         catch (Exception e)
         {

--- a/BlazorApp/Pages/Logout.razor
+++ b/BlazorApp/Pages/Logout.razor
@@ -8,6 +8,6 @@
     protected override async Task OnInitializedAsync()
     {
         await AuthService.LogoutAsync();
-        NavMgr.NavigateTo("/Login");
+        NavMgr.NavigateTo("Login");
     }
 }

--- a/BlazorApp/Pages/ViewTodos.razor
+++ b/BlazorApp/Pages/ViewTodos.razor
@@ -72,7 +72,7 @@ else
                             <FancyCheckBox IsCompleted="@item.IsCompleted" OnChange="@((status) => CompleteTodo(item, status))" />
                         </td>
                         <td class="table-actions">
-                            <button class="button secondary" @onclick="@(() => navMgr.NavigateTo($"/EditTodo/{item.Id}"))">Edit</button>
+                            <button class="button secondary" @onclick="@(() => navMgr.NavigateTo($"EditTodo/{item.Id}"))">Edit</button>
                             <button class="danger-button" @onclick="@(() => RemoveTodo(item.Id))">Delete</button>
                         </td>
                     </tr>


### PR DESCRIPTION
## Summary

This PR fixes a GitHub Pages routing issue in the Blazor frontend.

After login, the app was navigating to absolute routes like `/ViewTodos`. On GitHub Pages, that sends the browser to:

https://umarsalem.github.io/ViewTodos

But the app is hosted under:

https://umarsalem.github.io/TodoAppWasm/

So GitHub Pages showed a 404 page after successful login.

## Changes

- Changed post-login navigation from `/ViewTodos` to `ViewTodos`
- Changed create todo redirect from `/ViewTodos` to `ViewTodos`
- Changed edit todo redirect from `/ViewTodos` to `ViewTodos`
- Changed logout redirect from `/Login` to `Login`
- Changed edit todo navigation from `/EditTodo/{id}` to `EditTodo/{id}`

## Testing

- Built the Blazor app successfully with:

```powershell
dotnet build BlazorApp\BlazorApp.csproj --no-restore